### PR TITLE
Allow a wordpress api request to specify certain status codes it want…

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 httmock
 pytest
-pytest-cov
+pytest-cov<2.6.0
 coverage
 codecov

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -438,6 +438,24 @@ class WPAPITestCasesBase(unittest.TestCase):
         with self.assertRaises(UserWarning):
             self.wpapi.post('posts', data)
 
+    def test_APIPostBadDataHandleBadStatus(self):
+        """
+        Test handling explicitly a bad status code for a request.
+        """
+        nonce = "%f\u00ae" % random.random()
+
+        data = {
+            'a': nonce
+        }
+
+        response = self.wpapi.post('posts', data, handle_status_codes=[400])
+        self.assertEqual(response.status_code, 400)
+
+        # If we don't specify a correct status code to handle we should
+        # still expect an exception
+        with self.assertRaises(UserWarning):
+            self.wpapi.post('posts', data, handle_status_codes=[404])
+
     def test_APIPostMedia(self):
         img_path = 'tests/data/test.jpg'
         with open(img_path, 'rb') as test_file:

--- a/wordpress/api.py
+++ b/wordpress/api.py
@@ -219,6 +219,8 @@ class API(object):
             # enforce utf-8 encoded binary
             data = StrUtils.to_binary(data)
 
+        handle_status_codes = kwargs.pop('handle_status_codes', [])
+
         response = self.requester.request(
             method=method,
             url=endpoint_url,
@@ -227,7 +229,7 @@ class API(object):
             **kwargs
         )
 
-        if response.status_code not in [200, 201, 202]:
+        if response.status_code not in [200, 201, 202] + handle_status_codes:
             self.request_post_mortem(response)
 
         return response


### PR DESCRIPTION
…s to allow/handle in response.

There are many cases where I might decide eg a 400 response is helpful - I have an import script for which it's more convenient to try and post something, and handle a 400 - telling me the item is already there, from a previous run of the script... rather than querying if it's there then posting only if it's not (which may be on average a slower process especially on the first run.)